### PR TITLE
feat(llamacode-7b): add llamacode implementation

### DIFF
--- a/llamacode-7b/.gitignore
+++ b/llamacode-7b/.gitignore
@@ -1,0 +1,1 @@
+CodeLlama-7b-hf

--- a/llamacode-7b/instill.yaml
+++ b/llamacode-7b/instill.yaml
@@ -1,0 +1,9 @@
+build:
+  gpu: true
+  python_version: "3.11" # support only 3.11
+  system_packages:
+  python_packages:
+    - torch==2.2.0
+    - sentencepiece==0.1.99
+    - transformers==4.36.2
+    - accelerate==0.25.0

--- a/llamacode-7b/model.py
+++ b/llamacode-7b/model.py
@@ -1,9 +1,6 @@
 # pylint: skip-file
 import os
 
-# os.environ["CUDA_VISIBLE_DEVICES"] = f"0,1,2,3"
-os.environ["CUDA_VISIBLE_DEVICES"] = f"0"
-
 import time
 import torch
 import transformers
@@ -40,14 +37,9 @@ class CodeLlama:
         created = []
         contents = []
         for inp in completion_inputs:
-            conv = self.pipeline.tokenizer.apply_chat_template(
-                inp.prompt,
-                tokenize=False,
-                add_generation_prompt=True,
-            )
 
             sequences = self.pipeline(
-                conv,
+                inp.prompt,
                 do_sample=True,
                 temperature=inp.temperature,
                 top_p=inp.top_p,


### PR DESCRIPTION
Because

- Showcase llamacode-7b implementation that is Instill Model compatible

This commit

- add llamacode-7b implementation

Local test
```
llamacode-7b git:(heiru/INS-5716) instill run admin/llamacode -g -i '{"prompt": "def get_api_key():"}'
2024-08-08 16:52:16,595.595 INFO     [Instill] Starting model image...
2024-08-08 16:52:27,029.029 INFO     [Instill] Deploying model...
2024-08-08 16:53:06,820.820 INFO     [Instill] Running inference...
2024-08-08 01:53:11,774.774 INFO     [Instill] Outputs:
[{'data': {'choices': [{'content': 'def get_api_key():\n'
                                   '    return "dummykey"\n'
                                   '\n'
                                   '\n'
                                   '@pytest.fixture\n'
                                   'def get_api_secret():\n'
                                   '    return "dummysecret"\n'
                                   '\n'
                                   '\n'
                                   '@pytest.fixture\n'
                                   'def get_access_token():',
                        'created': 1723107191,
                        'finish-reason': 'length',
                        'index': 0}]}}]
2024-08-08 16:53:15,486.486 INFO     [Instill] Done
```