### PR TITLE
chore(llava): support only text input

### DIFF
--- a/llava-1-6-13b/v0.1.0/model.py
+++ b/llava-1-6-13b/v0.1.0/model.py
@@ -63,9 +63,11 @@ class Llava:
 
             prompt = conv.get_prompt()
 
-            image_tensors = process_images(
-                images, self.image_processor, {"image_aspect_ratio": "pad"}
-            ).to(self.model.device, dtype=torch.float16)
+            image_tensors = []
+            if len(images) > 0:
+                image_tensors = process_images(
+                    images, self.image_processor, {"image_aspect_ratio": "pad"}
+                ).to(self.model.device, dtype=torch.float16)
 
             input_ids = (
                 tokenizer_image_token(


### PR DESCRIPTION
Because

- If message inputs does not contain any image, model will have empty output

This commit

- support only text input
