### PR TITLE
docs(readme): populate models' readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ We have a diverse set of models, each optimized for different AI tasks. Please r
 
 | Model Name                                                     | Task Type             | Description                                                                                                            |
 | -------------------------------------------------------------- | --------------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| [phi-3.5-vision-instruct](./phi-3-5-vision/README.md)          | Chat                  | Phi-3.5-vision is a lightweight, state-of-the-art open multimodal model.                                               |
 | [gte-Qwen2-1.5B-instruct](./gte-Qwen2-1.5B-instruct/README.md) | Embedding             | gte-Qwen2-1.5B-instruct is the latest model in the gte (General Text Embedding) model family.                          |
 | [jina-clip-v1](./jina-clip-v1/README.md)                       | Embedding             | jina-clip-v1 is a state-of-the-art English multimodal (text-image) embedding model.                                    |
 | [llama2-7b-chat](./llama2-7b-chat/README.md)                   | Chat                  | llama2-7b-chat is optimized for dialogue use cases.                                                                    |

--- a/gte-Qwen2-1.5B-instruct/README.md
+++ b/gte-Qwen2-1.5B-instruct/README.md
@@ -1,0 +1,84 @@
+# gte Qwen2 1.5B Instruct
+
+## 📖 Introduction
+
+[gte-Qwen2-1.5B-instruct](https://huggingface.co/Alibaba-NLP/gte-Qwen2-1.5B-instruct) is the latest model in the gte (General Text Embedding) model family. The model is built on Qwen2-1.5B LLM model and use the same training data and strategies as the gte-Qwen2-7B-instruct model.
+
+| Task Type                                                          | Description                                                                                                          |
+| ------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------- |
+| [Embedding](https://www.instill.tech/docs/model/ai-task#embedding) | A task to generate means of representing objects like text, images and audio as points in a continuous vector space. |
+
+## 🔄 Compatibility Matrix
+
+To ensure smooth integration, please refer to the compatibility matrix below. It outlines the compatible versions of the model, [`instill-core`](https://github.com/instill-ai/instill-core), and the [`python-sdk`](https://github.com/instill-ai/python-sdk).
+
+| Model Version | Instill-Core Version | Python-SDK Version |
+| ------------- | -------------------- | ------------------ |
+| v0.1.0        | >v0.39.0-beta        | >0.11.0            |
+
+> **Note:** Always ensure that you are using compatible versions to avoid unexpected issues.
+
+## 🚀 Preparation
+
+Follow [this](../README.md) guide to get your custom model up and running! But before you do that, please read through the following sections to have all the necessary files ready.
+
+#### Install Python SDK
+
+Install the compatible [`python-sdk`](https://github.com/instill-ai/python-sdk) version according to the compatibility matrix:
+
+```bash
+pip install instill-sdk=={version}
+```
+
+#### Get model weights
+
+To download the fine-tuned model weights, please execute the following command:
+
+```bash
+git clone https://huggingface.co/Alibaba-NLP/gte-Qwen2-1.5B-instruct
+```
+
+## Test model image
+
+After you've built the model image, and before pushing the model onto any **Instill Core** instance, you can test if the model can be successfully run locally first, by running the following command:
+
+```bash
+instill run instill-ai/gte-qwen2-1.5b-instruct -g -i '{"prompt": "hi"}'
+```
+
+The input payload should strictly follow the the below format
+
+```json
+{
+  "prompt": "..."
+}
+```
+
+A successful response will return a similar output to that shown below.
+
+```bash
+2024-09-11 02:36:18,416.416 INFO     [Instill] Starting model image...
+2024-09-11 02:36:29,444.444 INFO     [Instill] Deploying model...
+2024-09-11 02:37:10,118.118 INFO     [Instill] Running inference...
+2024-09-11 02:37:11,585.585 INFO     [Instill] Outputs:
+[{'data': {'embeddings': [{'created': 1725993431,
+                           'index': 0,
+                           'vector': [0.014460443519055843,
+                                      0.0885428711771965,
+                                      0.02166132815182209,
+                                      ...
+                                      ...
+                                      ...
+                                      -0.02432815358042717]}]}}]
+2024-09-11 02:39:58,651.651 INFO     [Instill] Done
+```
+
+Here is the list of flags supported by `instill run` command
+
+- -t, --tag: tag for the model image, default to `latest`
+- -g, --gpu: to pass through GPU from host into container or not, depends on if `gpu` is enabled in the config.
+- -i, --input: input in json format
+
+---
+
+Happy Modeling! 💡

--- a/jina-clip-v1/README.md
+++ b/jina-clip-v1/README.md
@@ -1,0 +1,94 @@
+# Jina CLIP V1
+
+## 📖 Introduction
+
+[jina-clip-v1](https://huggingface.co/jinaai/jina-clip-v1) is a state-of-the-art English multimodal (text-image) embedding model.
+
+| Task Type                                                          | Description                                                                                                          |
+| ------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------- |
+| [Embedding](https://www.instill.tech/docs/model/ai-task#embedding) | A task to generate means of representing objects like text, images and audio as points in a continuous vector space. |
+
+## 🔄 Compatibility Matrix
+
+To ensure smooth integration, please refer to the compatibility matrix below. It outlines the compatible versions of the model, [`instill-core`](https://github.com/instill-ai/instill-core), and the [`python-sdk`](https://github.com/instill-ai/python-sdk).
+
+| Model Version | Instill-Core Version | Python-SDK Version |
+| ------------- | -------------------- | ------------------ |
+| v0.1.0        | >v0.39.0-beta        | >0.11.0            |
+
+> **Note:** Always ensure that you are using compatible versions to avoid unexpected issues.
+
+## 🚀 Preparation
+
+Follow [this](../README.md) guide to get your custom model up and running! But before you do that, please read through the following sections to have all the necessary files ready.
+
+#### Install Python SDK
+
+Install the compatible [`python-sdk`](https://github.com/instill-ai/python-sdk) version according to the compatibility matrix:
+
+```bash
+pip install instill-sdk=={version}
+```
+
+#### Get model weights
+
+To download the fine-tuned model weights, please execute the following command:
+
+```bash
+git clone https://huggingface.co/jinaai/jina-clip-v1
+```
+
+## Test model image
+
+After you've built the model image, and before pushing the model onto any **Instill Core** instance, you can test if the model can be successfully run locally first, by running the following command:
+
+```bash
+instill run instill-ai/jina-clip-v1 -g -i '{"text" : "hi", "image": "https://artifacts.instill.tech/imgs/bear.jpg"}'
+```
+
+The input payload should strictly follow the the below format
+
+```json
+{
+  "text": "...",
+  "image": "https://",
+}
+```
+
+A successful response will return a similar output to that shown below.
+
+```bash
+2024-09-11 02:42:38,605.605 INFO     [Instill] Starting model image...
+2024-09-11 02:42:49,440.440 INFO     [Instill] Deploying model...
+2024-09-11 02:43:16,851.851 INFO     [Instill] Running inference...
+2024-09-11 02:43:19,756.756 INFO     [Instill] Outputs:
+[{'data': {'embeddings': [{'created': 1725993799,
+                           'index': 0,
+                           'vector': [-0.042002271860837936,
+                                      0.002093376824632287,
+                                      0.007119686808437109,
+                                      ...
+                                      ...
+                                      ...
+                                      -0.0350787378847599]},
+                          {'created': 1725993799,
+                           'index': 1,
+                           'vector': [-0.07706715911626816,
+                                      -0.006987405009567738,
+                                      0.0100631695240736,
+                                      ...
+                                      ...
+                                      ...
+                                      -0.02432815358042717]}]}}]
+2024-09-11 02:43:23,487.487 INFO     [Instill] Done
+```
+
+Here is the list of flags supported by `instill run` command
+
+- -t, --tag: tag for the model image, default to `latest`
+- -g, --gpu: to pass through GPU from host into container or not, depends on if `gpu` is enabled in the config.
+- -i, --input: input in json format
+
+---
+
+Happy Modeling! 💡

--- a/llama2-7b-chat/README.md
+++ b/llama2-7b-chat/README.md
@@ -1,0 +1,83 @@
+# Llama2 7B Chat
+
+## 📖 Introduction
+
+[Llama 2](https://huggingface.co/meta-llama/Llama-2-7b-chat-hf) is a collection of pretrained and fine-tuned generative text models ranging in scale from 7 billion to 70 billion parameters. This is the repository for the 7B fine-tuned model, optimized for dialogue use cases and converted for the Hugging Face Transformers format.
+
+| Task Type                                                | Description                                                                                 |
+| -------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
+| [Chat](https://www.instill.tech/docs/model/ai-task#chat) | A task to generate conversational style text output base on single or multi-modality input. |
+
+## 🔄 Compatibility Matrix
+
+To ensure smooth integration, please refer to the compatibility matrix below. It outlines the compatible versions of the model, [`instill-core`](https://github.com/instill-ai/instill-core), and the [`python-sdk`](https://github.com/instill-ai/python-sdk).
+
+| Model Version | Instill-Core Version | Python-SDK Version |
+| ------------- | -------------------- | ------------------ |
+| v0.1.0        | >v0.39.0-beta        | >0.11.0            |
+
+> **Note:** Always ensure that you are using compatible versions to avoid unexpected issues.
+
+## 🚀 Preparation
+
+Follow [this](../README.md) guide to get your custom model up and running! But before you do that, please read through the following sections to have all the necessary files ready.
+
+#### Install Python SDK
+
+Install the compatible [`python-sdk`](https://github.com/instill-ai/python-sdk) version according to the compatibility matrix:
+
+```bash
+pip install instill-sdk=={version}
+```
+
+#### Get model weights
+
+To download the fine-tuned model weights, please execute the following command:
+
+```bash
+git clone https://huggingface.co/meta-llama/Llama-2-7b-chat-hf
+```
+
+## Test model image
+
+After you've built the model image, and before pushing the model onto any **Instill Core** instance, you can test if the model can be successfully run locally first, by running the following command:
+
+```bash
+instill run instill-ai/llama2-7b-chat -g -i '{"prompt": "hi"}'
+```
+
+The input payload should strictly follow the the below format
+
+```json
+{
+  "prompt": "..."
+}
+```
+
+A successful response will return a similar output to that shown below.
+
+```bash
+2024-09-11 01:44:12,423.423 INFO     [Instill] Starting model image...
+2024-09-11 01:44:22,843.843 INFO     [Instill] Deploying model...
+2024-09-11 01:44:52,935.935 INFO     [Instill] Running inference...
+2024-09-11 01:44:56,534.534 INFO     [Instill] Outputs:
+[{'data': {'choices': [{'created': 1725990296,
+                        'finish-reason': 'length',
+                        'index': 0,
+                        'message': {'content': "Hello! It's nice to meet you. "
+                                               'Is there something I can help '
+                                               'you with or would you like to '
+                                               'chat?',
+                                    'role': 'assistant'}}]}}]
+2024-09-11 01:45:00,240.240 INFO     [Instill] Done
+```
+
+Here is the list of flags supported by `instill run` command
+
+- -t, --tag: tag for the model image, default to `latest`
+- -g, --gpu: to pass through GPU from host into container or not, depends on if `gpu` is enabled in the config.
+- -i, --input: input in json format
+
+---
+
+Happy Modeling! 💡

--- a/llama3-8b-instruct/README.md
+++ b/llama3-8b-instruct/README.md
@@ -1,0 +1,87 @@
+# Llama3 8B Instruct
+
+## 📖 Introduction
+
+Meta developed and released the Meta [Llama 3](https://huggingface.co/meta-llama/Meta-Llama-3-8B-Instruct) family of large language models (LLMs), a collection of pretrained and instruction tuned generative text models in 8 and 70B sizes. The Llama 3 instruction tuned models are optimized for dialogue use cases and outperform many of the available open source chat models on common industry benchmarks.
+
+| Task Type                                                | Description                                                                                 |
+| -------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
+| [Chat](https://www.instill.tech/docs/model/ai-task#chat) | A task to generate conversational style text output base on single or multi-modality input. |
+
+## 🔄 Compatibility Matrix
+
+To ensure smooth integration, please refer to the compatibility matrix below. It outlines the compatible versions of the model, [`instill-core`](https://github.com/instill-ai/instill-core), and the [`python-sdk`](https://github.com/instill-ai/python-sdk).
+
+| Model Version | Instill-Core Version | Python-SDK Version |
+| ------------- | -------------------- | ------------------ |
+| v0.1.0        | >v0.39.0-beta        | >0.11.0            |
+
+> **Note:** Always ensure that you are using compatible versions to avoid unexpected issues.
+
+## 🚀 Preparation
+
+Follow [this](../README.md) guide to get your custom model up and running! But before you do that, please read through the following sections to have all the necessary files ready.
+
+#### Install Python SDK
+
+Install the compatible [`python-sdk`](https://github.com/instill-ai/python-sdk) version according to the compatibility matrix:
+
+```bash
+pip install instill-sdk=={version}
+```
+
+#### Get model weights
+
+To download the fine-tuned model weights, please execute the following command:
+
+```bash
+git clone https://huggingface.co/meta-llama/Meta-Llama-3-8B-Instruct
+```
+
+## Test model image
+
+After you've built the model image, and before pushing the model onto any **Instill Core** instance, you can test if the model can be successfully run locally first, by running the following command:
+
+```bash
+instill run instill-ai/llama3-8b-instruct -g -i '{"prompt": "hows life?"}'
+```
+
+The input payload should strictly follow the the below format
+
+```json
+{
+  "prompt": "..."
+}
+```
+
+A successful response will return a similar output to that shown below.
+
+```bash
+2024-09-11 01:48:37,795.795 INFO     [Instill] Starting model image...
+2024-09-11 01:48:48,785.785 INFO     [Instill] Deploying model...
+2024-09-11 01:49:28,613.613 INFO     [Instill] Running inference...
+2024-09-11 01:49:33,350.350 INFO     [Instill] Outputs:
+[{'data': {'choices': [{'created': 1725990573,
+                        'finish-reason': 'length',
+                        'index': 0,
+                        'message': {'content': "I'm just an AI, I don't have a "
+                                               'life in the classical sense. I '
+                                               'exist solely to assist and '
+                                               'communicate with users like '
+                                               "you. I don't have emotions, "
+                                               'experiences, or personal '
+                                               "relationships. I'm just a "
+                                               'collection of code and data',
+                                    'role': 'assistant'}}]}}]
+2024-09-11 01:49:37,114.114 INFO     [Instill] Done
+```
+
+Here is the list of flags supported by `instill run` command
+
+- -t, --tag: tag for the model image, default to `latest`
+- -g, --gpu: to pass through GPU from host into container or not, depends on if `gpu` is enabled in the config.
+- -i, --input: input in json format
+
+---
+
+Happy Modeling! 💡

--- a/llamacode-7b/README.md
+++ b/llamacode-7b/README.md
@@ -1,0 +1,83 @@
+# Llama Code 7B
+
+## 📖 Introduction
+
+[Code Llama](https://huggingface.co/codellama/CodeLlama-7b-hf) is a collection of pretrained and fine-tuned generative text models ranging in scale from 7 billion to 34 billion parameters. This is the repository for the base 7B version in the Hugging Face Transformers format. This model is designed for general code synthesis and understanding.
+
+| Task Type                                                            | Description                                                          |
+| -------------------------------------------------------------------- | -------------------------------------------------------------------- |
+| [Completion](https://www.instill.tech/docs/model/ai-task#completion) | A task to generate natural continuation texts based on input prompt. |
+
+## 🔄 Compatibility Matrix
+
+To ensure smooth integration, please refer to the compatibility matrix below. It outlines the compatible versions of the model, [`instill-core`](https://github.com/instill-ai/instill-core), and the [`python-sdk`](https://github.com/instill-ai/python-sdk).
+
+| Model Version | Instill-Core Version | Python-SDK Version |
+| ------------- | -------------------- | ------------------ |
+| v0.1.0        | >v0.39.0-beta        | >0.11.0            |
+
+> **Note:** Always ensure that you are using compatible versions to avoid unexpected issues.
+
+## 🚀 Preparation
+
+Follow [this](../README.md) guide to get your custom model up and running! But before you do that, please read through the following sections to have all the necessary files ready.
+
+#### Install Python SDK
+
+Install the compatible [`python-sdk`](https://github.com/instill-ai/python-sdk) version according to the compatibility matrix:
+
+```bash
+pip install instill-sdk=={version}
+```
+
+#### Get model weights
+
+To download the fine-tuned model weights, please execute the following command:
+
+```bash
+git clone https://huggingface.co/codellama/CodeLlama-7b-hf
+```
+
+## Test model image
+
+After you've built the model image, and before pushing the model onto any **Instill Core** instance, you can test if the model can be successfully run locally first, by running the following command:
+
+```bash
+instill run instill-ai/llamacode-7b -g -i '{"prompt": "go func("}'
+```
+
+The input payload should strictly follow the the below format
+
+```json
+{
+  "prompt": "..."
+}
+```
+
+A successful response will return a similar output to that shown below.
+
+```bash
+2024-09-11 02:03:26,813.813 INFO     [Instill] Starting model image...
+2024-09-11 02:03:37,228.228 INFO     [Instill] Deploying model...
+2024-09-11 02:04:37,750.750 INFO     [Instill] Running inference...
+2024-09-11 02:04:42,434.434 INFO     [Instill] Outputs:
+[{'data': {'choices': [{'content': 'go func(interface{}) error, interceptor '
+                                   'grpc.UnaryServerInterceptor) (interface{}, '
+                                   'error) {\n'
+                                   '\tin := new(SayHelloReq)\n'
+                                   '\tif err := dec(in); err!= nil {',
+                        'created': 1725991482,
+                        'finish-reason': 'length',
+                        'index': 0}]}}]
+2024-09-11 02:04:46,147.147 INFO     [Instill] Done
+```
+
+Here is the list of flags supported by `instill run` command
+
+- -t, --tag: tag for the model image, default to `latest`
+- -g, --gpu: to pass through GPU from host into container or not, depends on if `gpu` is enabled in the config.
+- -i, --input: input in json format
+
+---
+
+Happy Modeling! 💡

--- a/llava-1-6-13b/README.md
+++ b/llava-1-6-13b/README.md
@@ -1,0 +1,88 @@
+# Llava 1.6 13B
+
+## 📖 Introduction
+
+[LLaVA](https://huggingface.co/liuhaotian/llava-v1.6-vicuna-13b) is an open-source chatbot trained by fine-tuning LLM on multimodal instruction-following data. It is an auto-regressive language model, based on the transformer architecture.
+
+| Task Type                                                | Description                                                                                 |
+| -------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
+| [Chat](https://www.instill.tech/docs/model/ai-task#chat) | A task to generate conversational style text output base on single or multi-modality input. |
+
+## 🔄 Compatibility Matrix
+
+To ensure smooth integration, please refer to the compatibility matrix below. It outlines the compatible versions of the model, [`instill-core`](https://github.com/instill-ai/instill-core), and the [`python-sdk`](https://github.com/instill-ai/python-sdk).
+
+| Model Version | Instill-Core Version | Python-SDK Version |
+| ------------- | -------------------- | ------------------ |
+| v0.1.0        | >v0.39.0-beta        | >0.11.0            |
+
+> **Note:** Always ensure that you are using compatible versions to avoid unexpected issues.
+
+## 🚀 Preparation
+
+Follow [this](../README.md) guide to get your custom model up and running! But before you do that, please read through the following sections to have all the necessary files ready.
+
+#### Install Python SDK
+
+Install the compatible [`python-sdk`](https://github.com/instill-ai/python-sdk) version according to the compatibility matrix:
+
+```bash
+pip install instill-sdk=={version}
+```
+
+#### Get model weights
+
+To download the fine-tuned model weights, please execute the following command:
+
+```bash
+git clone https://huggingface.co/liuhaotian/llava-v1.6-vicuna-13b
+```
+
+## Test model image
+
+After you've built the model image, and before pushing the model onto any **Instill Core** instance, you can test if the model can be successfully run locally first, by running the following command:
+
+```bash
+instill run instill-ai/llava-1-6-13b -g -i '{"prompt": "whats in the pic?", "image-url": "https://artifacts.instill.tech/imgs/bear.jpg"}'
+```
+
+The input payload should strictly follow the the below format
+
+```json
+{
+  "prompt": "...",
+  "image-url": "https://..."
+}
+```
+
+A successful response will return a similar output to that shown below.
+
+```bash
+2024-09-11 01:54:17,944.944 INFO     [Instill] Starting model image...
+2024-09-11 01:54:28,926.926 INFO     [Instill] Deploying model...
+2024-09-11 01:57:46,629.629 INFO     [Instill] Running inference...
+2024-09-11 01:58:15,578.578 INFO     [Instill] Outputs:
+[{'data': {'choices': [{'created': 1725991095,
+                        'finish-reason': 'length',
+                        'index': 0,
+                        'message': {'content': 'The image shows a bear sitting '
+                                               'in a field. The bear appears '
+                                               'to be in a relaxed posture '
+                                               'with one paw raised in the air '
+                                               'as if waving. The background '
+                                               'suggests a natural, open '
+                                               'habitat, possibly a grassy '
+                                               'area with trees',
+                                    'role': 'assistant'}}]}}]
+2024-09-11 01:58:19,447.447 INFO     [Instill] Done
+```
+
+Here is the list of flags supported by `instill run` command
+
+- -t, --tag: tag for the model image, default to `latest`
+- -g, --gpu: to pass through GPU from host into container or not, depends on if `gpu` is enabled in the config.
+- -i, --input: input in json format
+
+---
+
+Happy Modeling! 💡

--- a/mobilenetv2/README.md
+++ b/mobilenetv2/README.md
@@ -1,10 +1,77 @@
----
-Task: Classification
-Tags:
-  - Classification
-  - MobileNetV2
+# MobilenetV2
+
+## 📖 Introduction
+
+[MobileNetV2](https://arxiv.org/abs/1801.04381) is a new mobile architecture that improves the state of the art performance of mobile models on multiple tasks and benchmarks as well as across a spectrum of different model sizes.
+
+| Task Type                                                                          | Description                                                                         |
+| ---------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
+| [Classification](https://www.instill.tech/docs/model/ai-task#image-classification) | Vision task to assign a single pre-defined category label to an entire input image. |
+
+## 🔄 Compatibility Matrix
+
+To ensure smooth integration, please refer to the compatibility matrix below. It outlines the compatible versions of the model, [`instill-core`](https://github.com/instill-ai/instill-core), and the [`python-sdk`](https://github.com/instill-ai/python-sdk).
+
+| Model Version | Instill-Core Version | Python-SDK Version |
+| ------------- | -------------------- | ------------------ |
+| v0.1.0        | >v0.39.0-beta        | >0.11.0            |
+
+> **Note:** Always ensure that you are using compatible versions to avoid unexpected issues.
+
+## 🚀 Preparation
+
+Follow [this](../README.md) guide to get your custom model up and running! But before you do that, please read through the following sections to have all the necessary files ready.
+
+#### Install Python SDK
+
+Install the compatible [`python-sdk`](https://github.com/instill-ai/python-sdk) version according to the compatibility matrix:
+
+```bash
+pip install instill-sdk=={version}
+```
+
+#### Get model weights
+
+To download the fine-tuned model weights, please execute the following command:
+
+```bash
+curl -o model.onnx https://artifacts.instill.tech/model/mobilenetv2/model.onnx
+```
+
+## Test model image
+
+After you've built the model image, and before pushing the model onto any **Instill Core** instance, you can test if the model can be successfully run locally first, by running the following command:
+
+```bash
+instill run instill-ai/mobilenetv2 -i '{"image-url": "https://artifacts.instill.tech/imgs/bear.jpg", "type": "image-url"}'
+```
+
+The input payload should strictly follow the the below format
+
+```json
+{
+  "image-url": "https://...",
+  "type": "image-url"
+}
+```
+
+A successful response will return a similar output to that shown below.
+
+```bash
+2024-09-11 02:19:20,870.870 INFO     [Instill] Starting model image...
+2024-09-11 02:19:31,172.172 INFO     [Instill] Deploying model...
+2024-09-11 02:19:44,971.971 INFO     [Instill] Running inference...
+2024-09-11 02:19:46,726.726 INFO     [Instill] Outputs:
+[{'data': {'category': 'brown bear', 'score': 0.9989921450614929}}]
+2024-09-11 02:19:50,993.993 INFO     [Instill] Done
+```
+
+Here is the list of flags supported by `instill run` command
+
+- -t, --tag: tag for the model image, default to `latest`
+- -g, --gpu: to pass through GPU from host into container or not, depends on if `gpu` is enabled in the config.
+- -i, --input: input in json format
+
 ---
 
-# Model MobileNet v2
-
-Instill Model compatible implementation of [MobileNet v2](https://github.com/onnx/models/tree/main/vision/classification/mobilenet) model.
+Happy Modeling! 💡

--- a/phi-3-5-vision/README.md
+++ b/phi-3-5-vision/README.md
@@ -1,0 +1,84 @@
+# Phi 3.5 Vision
+
+## 📖 Introduction
+
+[Phi-3.5-vision](https://huggingface.co/microsoft/Phi-3.5-vision-instruct) is a lightweight, state-of-the-art open multimodal model built upon datasets which include - synthetic data and filtered publicly available websites - with a focus on very high-quality, reasoning dense data both on text and vision. The model belongs to the Phi-3 model family, and the multimodal version comes with 128K context length (in tokens) it can support. The model underwent a rigorous enhancement process, incorporating both supervised fine-tuning and direct preference optimization to ensure precise instruction adherence and robust safety measures.
+
+| Task Type                                                | Description                                                                                 |
+| -------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
+| [Chat](https://www.instill.tech/docs/model/ai-task#chat) | A task to generate conversational style text output base on single or multi-modality input. |
+
+## 🔄 Compatibility Matrix
+
+To ensure smooth integration, please refer to the compatibility matrix below. It outlines the compatible versions of the model, [`instill-core`](https://github.com/instill-ai/instill-core), and the [`python-sdk`](https://github.com/instill-ai/python-sdk).
+
+| Model Version | Instill-Core Version | Python-SDK Version |
+| ------------- | -------------------- | ------------------ |
+| v0.1.0        | >v0.39.0-beta        | >0.11.0            |
+
+> **Note:** Always ensure that you are using compatible versions to avoid unexpected issues.
+
+## 🚀 Preparation
+
+Follow [this](../README.md) guide to get your custom model up and running! But before you do that, please read through the following sections to have all the necessary files ready.
+
+#### Install Python SDK
+
+Install the compatible [`python-sdk`](https://github.com/instill-ai/python-sdk) version according to the compatibility matrix:
+
+```bash
+pip install instill-sdk=={version}
+```
+
+#### Get model weights
+
+To download the fine-tuned model weights, please execute the following command:
+
+```bash
+git clone https://huggingface.co/microsoft/Phi-3.5-vision-instruct
+```
+
+## Test model image
+
+After you've built the model image, and before pushing the model onto any **Instill Core** instance, you can test if the model can be successfully run locally first, by running the following command:
+
+```bash
+instill run instill-ai/phi-3-5-vision -g -i '{"prompt": "whats in the pic?", "image-url": "https://artifacts.instill.tech/imgs/bear.jpg"}'
+```
+
+The input payload should strictly follow the the below format
+
+```json
+{
+  "prompt": "...",
+  "image-url": "https://..."
+}
+```
+
+A successful response will return a similar output to that shown below.
+
+```bash
+2024-09-12 17:26:28,145.145 INFO     [Instill] Starting model image...
+2024-09-12 17:26:38,573.573 INFO     [Instill] Deploying model...
+2024-09-12 17:27:02,953.953 INFO     [Instill] Running inference...
+2024-09-12 17:27:07,323.323 INFO     [Instill] Outputs:
+[{'data': {'choices': [{'created': 1726133227,
+                        'finish-reason': 'length',
+                        'index': 0,
+                        'message': {'content': 'The image shows a brown bear '
+                                               'sitting on its hind legs in a '
+                                               'grassy field with trees in the '
+                                               'background.',
+                                    'role': 'assistant'}}]}}]
+2024-09-12 17:27:10,834.834 INFO     [Instill] Done
+```
+
+Here is the list of flags supported by `instill run` command
+
+- -t, --tag: tag for the model image, default to `latest`
+- -g, --gpu: to pass through GPU from host into container or not, depends on if `gpu` is enabled in the config.
+- -i, --input: input in json format
+
+---
+
+Happy Modeling! 💡

--- a/stable-diffusion-xl/README.md
+++ b/stable-diffusion-xl/README.md
@@ -1,0 +1,78 @@
+# Stable Diffusion XL
+
+## 📖 Introduction
+
+[SDXL](https://huggingface.co/stabilityai/stable-diffusion-xl-base-1.0) consists of an ensemble of experts pipeline for latent diffusion: In a first step, the base model is used to generate (noisy) latents, which are then further processed with a refinement model specialized for the final denoising steps.
+
+| Task Type                                                                  | Description                                                                                                                                                                           |
+| -------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [Text to Image](https://www.instill.tech/docs/model/ai-task#text-to-image) | A task to generate images from text inputs. Generally, the task takes descriptive text prompts as the input, and outputs generated images in Base64 format based on the text prompts. |
+
+## 🔄 Compatibility Matrix
+
+To ensure smooth integration, please refer to the compatibility matrix below. It outlines the compatible versions of the model, [`instill-core`](https://github.com/instill-ai/instill-core), and the [`python-sdk`](https://github.com/instill-ai/python-sdk).
+
+| Model Version | Instill-Core Version | Python-SDK Version |
+| ------------- | -------------------- | ------------------ |
+| v0.1.0        | >v0.39.0-beta        | >0.11.0            |
+
+> **Note:** Always ensure that you are using compatible versions to avoid unexpected issues.
+
+## 🚀 Preparation
+
+Follow [this](../README.md) guide to get your custom model up and running! But before you do that, please read through the following sections to have all the necessary files ready.
+
+#### Install Python SDK
+
+Install the compatible [`python-sdk`](https://github.com/instill-ai/python-sdk) version according to the compatibility matrix:
+
+```bash
+pip install instill-sdk=={version}
+```
+
+#### Get model weights
+
+To download the fine-tuned model weights, please execute the following command:
+
+```bash
+git clone https://huggingface.co/stabilityai/stable-diffusion-xl-base-1.0
+git clone https://huggingface.co/stabilityai/stable-diffusion-xl-refiner-1.0
+```
+
+## Test model image
+
+After you've built the model image, and before pushing the model onto any **Instill Core** instance, you can test if the model can be successfully run locally first, by running the following command:
+
+```bash
+instill run instill-ai/stable-diffusion-xl -g -i '{"prompt": "cat napping"}'
+```
+
+The input payload should strictly follow the the below format
+
+```json
+{
+  "prompt": "..."
+}
+```
+
+A successful response will return a similar output to that shown below.
+
+```bash
+2024-09-11 02:23:19,079.079 INFO     [Instill] Starting model image...
+2024-09-11 02:23:29,503.503 INFO     [Instill] Deploying model...
+2024-09-11 02:25:28,298.298 INFO     [Instill] Running inference...
+2024-09-11 02:25:45,534.534 INFO     [Instill] Outputs:
+[{'data': {'choices': [{'finish-reason': 'success',
+                        'image': 'data:image/jpeg;base64,/9j/7gAOQWRvY...'}]}}]
+2024-09-11 02:25:46,962.962 INFO     [Instill] Done
+```
+
+Here is the list of flags supported by `instill run` command
+
+- -t, --tag: tag for the model image, default to `latest`
+- -g, --gpu: to pass through GPU from host into container or not, depends on if `gpu` is enabled in the config.
+- -i, --input: input in json format
+
+---
+
+Happy Modeling! 💡

--- a/stella-en-1.5B-v5/README.md
+++ b/stella-en-1.5B-v5/README.md
@@ -1,0 +1,84 @@
+# Stella 1.5B V5
+
+## 📖 Introduction
+
+[stella_en_1.5B_v5](https://huggingface.co/dunzhang/stella_en_1.5B_v5) are trained based on Alibaba-NLP/gte-large-en-v1.5 and Alibaba-NLP/gte-Qwen2-1.5B-instruct.
+
+| Task Type                                                          | Description                                                                                                          |
+| ------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------- |
+| [Embedding](https://www.instill.tech/docs/model/ai-task#embedding) | A task to generate means of representing objects like text, images and audio as points in a continuous vector space. |
+
+## 🔄 Compatibility Matrix
+
+To ensure smooth integration, please refer to the compatibility matrix below. It outlines the compatible versions of the model, [`instill-core`](https://github.com/instill-ai/instill-core), and the [`python-sdk`](https://github.com/instill-ai/python-sdk).
+
+| Model Version | Instill-Core Version | Python-SDK Version |
+| ------------- | -------------------- | ------------------ |
+| v0.1.0        | >v0.39.0-beta        | >0.11.0            |
+
+> **Note:** Always ensure that you are using compatible versions to avoid unexpected issues.
+
+## 🚀 Preparation
+
+Follow [this](../README.md) guide to get your custom model up and running! But before you do that, please read through the following sections to have all the necessary files ready.
+
+#### Install Python SDK
+
+Install the compatible [`python-sdk`](https://github.com/instill-ai/python-sdk) version according to the compatibility matrix:
+
+```bash
+pip install instill-sdk=={version}
+```
+
+#### Get model weights
+
+To download the fine-tuned model weights, please execute the following command:
+
+```bash
+git clone https://huggingface.co/dunzhang/stella_en_1.5B_v5
+```
+
+## Test model image
+
+After you've built the model image, and before pushing the model onto any **Instill Core** instance, you can test if the model can be successfully run locally first, by running the following command:
+
+```bash
+instill run instill-ai/stella-en-1.5b-v5 -g -i '{"prompt": "hi"}'
+```
+
+The input payload should strictly follow the the below format
+
+```json
+{
+  "prompt": "..."
+}
+```
+
+A successful response will return a similar output to that shown below.
+
+```bash
+2024-09-11 02:32:08,736.736 INFO     [Instill] Starting model image...
+2024-09-11 02:32:19,460.460 INFO     [Instill] Deploying model...
+2024-09-11 02:32:53,543.543 INFO     [Instill] Running inference...
+2024-09-11 02:32:54,233.945 INFO     [Instill] Outputs:
+[{'data': {'embeddings': [{'created': 1725993175,
+                           'index': 0,
+                           'vector': [0.6914126873016357,
+                                      -1.073114037513733,
+                                      1.0187621116638184,
+                                      ...
+                                      ...
+                                      ...
+                                      3.1021170616149902]}]}}]
+2024-09-11 02:32:58,651.651 INFO     [Instill] Done
+```
+
+Here is the list of flags supported by `instill run` command
+
+- -t, --tag: tag for the model image, default to `latest`
+- -g, --gpu: to pass through GPU from host into container or not, depends on if `gpu` is enabled in the config.
+- -i, --input: input in json format
+
+---
+
+Happy Modeling! 💡

--- a/tinyllama/README.md
+++ b/tinyllama/README.md
@@ -1,12 +1,84 @@
----
-Task: TextGenerationChat
-Tags:
-  - TextGenerationChat
-  - TextGeneration
-  - Chat
-  - TinyLlama
+# TinyLlama 1.1B
+
+## 📖 Introduction
+
+[TinyLlama](https://huggingface.co/TinyLlama/TinyLlama-1.1B-Chat-v1.0) project aims to pretrain a 1.1B Llama model on 3 trillion tokens. It adopted exactly the same architecture and tokenizer as Llama 2. This means TinyLlama can be plugged and played in many open-source projects built upon Llama. Besides, TinyLlama is compact with only 1.1B parameters. This compactness allows it to cater to a multitude of applications demanding a restricted computation and memory footprint.
+
+| Task Type                                                | Description                                                                                 |
+| -------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
+| [Chat](https://www.instill.tech/docs/model/ai-task#chat) | A task to generate conversational style text output base on single or multi-modality input. |
+
+## 🔄 Compatibility Matrix
+
+To ensure smooth integration, please refer to the compatibility matrix below. It outlines the compatible versions of the model, [`instill-core`](https://github.com/instill-ai/instill-core), and the [`python-sdk`](https://github.com/instill-ai/python-sdk).
+
+| Model Version | Instill-Core Version | Python-SDK Version |
+| ------------- | -------------------- | ------------------ |
+| v0.1.0        | >v0.39.0-beta        | >0.11.0            |
+
+> **Note:** Always ensure that you are using compatible versions to avoid unexpected issues.
+
+## 🚀 Preparation
+
+Follow [this](../README.md) guide to get your custom model up and running! But before you do that, please read through the following sections to have all the necessary files ready.
+
+#### Install Python SDK
+
+Install the compatible [`python-sdk`](https://github.com/instill-ai/python-sdk) version according to the compatibility matrix:
+
+```bash
+pip install instill-sdk=={version}
+```
+
+#### Get model weights
+
+To download the fine-tuned model weights, please execute the following command:
+
+```bash
+git clone https://huggingface.co/TinyLlama/TinyLlama-1.1B-Chat-v1.0 tinyllama
+```
+
+## Test model image
+
+After you've built the model image, and before pushing the model onto any **Instill Core** instance, you can test if the model can be successfully run locally first, by running the following command:
+
+```bash
+instill run instill-ai/tinyllama -g -i '{"prompt": "hows your day?"}'
+```
+
+The input payload should strictly follow the the below format
+
+```json
+{
+  "prompt": "..."
+}
+```
+
+A successful response will return a similar output to that shown below.
+
+```bash
+2024-09-11 02:11:24,279.279 INFO     [Instill] Starting model image...
+2024-09-11 02:11:34,709.709 INFO     [Instill] Deploying model...
+2024-09-11 02:11:59,822.822 INFO     [Instill] Running inference...
+2024-09-11 02:12:03,578.578 INFO     [Instill] Outputs:
+[{'data': {'choices': [{'created': 1725991923,
+                        'finish-reason': 'length',
+                        'index': 0,
+                        'message': {'content': 'I don\'t have a personal '
+                                               'experience, but I can tell you '
+                                               'that your day sounds fine. '
+                                               'Hope you are having a great '
+                                               'time and doing well!',
+                                    'role': 'assistant'}}]}}]
+2024-09-11 02:12:07,153.153 INFO     [Instill] Done
+```
+
+Here is the list of flags supported by `instill run` command
+
+- -t, --tag: tag for the model image, default to `latest`
+- -g, --gpu: to pass through GPU from host into container or not, depends on if `gpu` is enabled in the config.
+- -i, --input: input in json format
+
 ---
 
-# Model-TinyLlama-1.1B
-
-🔥🔥🔥 Instill Model compatible implementation of [TinyLlama-1.1B-Chat-v1.0](https://huggingface.co/TinyLlama/TinyLlama-1.1B-Chat-v1.0)
+Happy Modeling! 💡

--- a/yolov7-stomata/README.md
+++ b/yolov7-stomata/README.md
@@ -47,13 +47,22 @@ After you've built the model image, and before pushing the model onto any **Inst
 instill run admin/yolov7-stomata -i '{"image-url": "https://microscopyofnature.com/sites/default/files/2022-03/Mais-stomata-ZW10.jpg", "type": "image-url"}'
 ```
 
+The input payload should strictly follow the the below format
+
+```json
+{
+  "image-url": "https://...",
+  "type": "image-url"
+}
+```
+
 A successful response will return a similar output to that shown below.
 
 ```bash
 2024-09-04 00:17:41,512.512 INFO     [Instill] Starting model image...
 2024-09-04 00:17:51,820.820 INFO     [Instill] Deploying model...
 2024-09-04 00:17:53,510.510 INFO     [Instill] Running inference...
-2024-09-03 09:17:57,564.564 INFO     [Instill] Outputs:
+2024-09-04 00:17:57,564.564 INFO     [Instill] Outputs:
 [
     {
         "data": {
@@ -100,6 +109,12 @@ A successful response will return a similar output to that shown below.
 ]
 2024-09-04 00:18:00,141.141 INFO     [Instill] Done
 ```
+
+Here is the list of flags supported by `instill run` command
+
+- -t, --tag: tag for the model image, default to `latest`
+- -g, --gpu: to pass through GPU from host into container or not, depends on if `gpu` is enabled in the config.
+- -i, --input: input in json format
 
 ---
 

--- a/yolov7/README.md
+++ b/yolov7/README.md
@@ -1,10 +1,90 @@
----
-Task: Detection
-Tags:
-  - Detection
-  - YOLOv7
+# Yolov7 object detector
+
+## 📖 Introduction
+
+[yolov7](https://github.com/WongKinYiu/yolov7) is a machine learning model trained for object detection task, check out the [paper](https://arxiv.org/abs/2207.02696) to lean more.
+
+| Task Type                                                                        | Description                                                                             |
+| -------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------- |
+| [Object Detection](https://www.instill.tech/docs/model/ai-task#object-detection) | A vision task to localise multiple objects of pre-defined categories in an input image. |
+
+## 🔄 Compatibility Matrix
+
+To ensure smooth integration, please refer to the compatibility matrix below. It outlines the compatible versions of the model, [`instill-core`](https://github.com/instill-ai/instill-core), and the [`python-sdk`](https://github.com/instill-ai/python-sdk).
+
+| Model Version | Instill-Core Version | Python-SDK Version |
+| ------------- | -------------------- | ------------------ |
+| v0.1.0        | >v0.39.0-beta        | >0.11.0            |
+
+> **Note:** Always ensure that you are using compatible versions to avoid unexpected issues.
+
+## 🚀 Preparation
+
+Follow [this](../README.md) guide to get your custom model up and running! But before you do that, please read through the following sections to have all the necessary files ready.
+
+#### Install Python SDK
+
+Install the compatible [`python-sdk`](https://github.com/instill-ai/python-sdk) version according to the compatibility matrix:
+
+```bash
+pip install instill-sdk=={version}
+```
+
+#### Get model weights
+
+To download the fine-tuned model weights, please execute the following command:
+
+```bash
+curl -o model.onnx https://artifacts.instill.tech/model/yolov7/model.onnx
+```
+
+## Test model image
+
+After you've built the model image, and before pushing the model onto any **Instill Core** instance, you can test if the model can be successfully run locally first, by running the following command:
+
+```bash
+instill run admin/yolov7 -i '{"image-url": "https://artifacts.instill.tech/imgs/bear.jpg", "type": "image-url"}'
+```
+
+The input payload should strictly follow the the below format
+
+```json
+{
+  "image-url": "https://...",
+  "type": "image-url"
+}
+```
+
+A successful response will return a similar output to that shown below.
+
+```bash
+2024-09-10 16:12:20,040.040 INFO     [Instill] Starting model image...
+2024-09-10 16:12:30,257.257 INFO     [Instill] Deploying model...
+2024-09-10 16:12:31,827.827 INFO     [Instill] Running inference...
+2024-09-10 16:12:33,703.703 INFO     [Instill] Outputs:
+[
+    {'data': {'objects': [
+                {'bounding-box': {'height': 757.0,
+                                         'left': 290.0,
+                                         'top': 84.0,
+                                         'width': 554.0
+                    },
+                        'category': 'bear',
+                        'score': 0.9658154845237732
+                }
+            ]
+        }
+    }
+]
+2024-09-10 16:12:37,387.387 INFO     [Instill] Done
+```
+
+Here is the list of flags supported by `instill run` command
+
+- -t, --tag: tag for the model image, default to `latest`
+- -g, --gpu: to pass through GPU from host into container or not, depends on if `gpu` is enabled in the config.
+- -i, --input: input in json format
+
 ---
 
-# Model-YOLOv7-DVC
-
-🔥🔥🔥 Instill Model compatible implementation of [YOLOv7](https://github.com/WongKinYiu/yolov7) model.
+Happy Modeling! 💡

--- a/zephyr-7b/README.md
+++ b/zephyr-7b/README.md
@@ -1,0 +1,81 @@
+# Zephyr 7B
+
+## 📖 Introduction
+
+[Zephyr](https://huggingface.co/HuggingFaceH4/zephyr-7b-alpha) is a series of language models that are trained to act as helpful assistants. Zephyr-7B-α is the first model in the series, and is a fine-tuned version of mistralai/Mistral-7B-v0.1 that was trained on on a mix of publicly available, synthetic datasets using Direct Preference Optimization (DPO).
+
+| Task Type                                                | Description                                                                                 |
+| -------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
+| [Chat](https://www.instill.tech/docs/model/ai-task#chat) | A task to generate conversational style text output base on single or multi-modality input. |
+
+## 🔄 Compatibility Matrix
+
+To ensure smooth integration, please refer to the compatibility matrix below. It outlines the compatible versions of the model, [`instill-core`](https://github.com/instill-ai/instill-core), and the [`python-sdk`](https://github.com/instill-ai/python-sdk).
+
+| Model Version | Instill-Core Version | Python-SDK Version |
+| ------------- | -------------------- | ------------------ |
+| v0.1.0        | >v0.39.0-beta        | >0.11.0            |
+
+> **Note:** Always ensure that you are using compatible versions to avoid unexpected issues.
+
+## 🚀 Preparation
+
+Follow [this](../README.md) guide to get your custom model up and running! But before you do that, please read through the following sections to have all the necessary files ready.
+
+#### Install Python SDK
+
+Install the compatible [`python-sdk`](https://github.com/instill-ai/python-sdk) version according to the compatibility matrix:
+
+```bash
+pip install instill-sdk=={version}
+```
+
+#### Get model weights
+
+To download the fine-tuned model weights, please execute the following command:
+
+```bash
+git clone https://huggingface.co/HuggingFaceH4/zephyr-7b-alpha
+```
+
+## Test model image
+
+After you've built the model image, and before pushing the model onto any **Instill Core** instance, you can test if the model can be successfully run locally first, by running the following command:
+
+```bash
+instill run instill-ai/zephyr-7b -g -i '{"prompt": "hi"}'
+```
+
+The input payload should strictly follow the the below format
+
+```json
+{
+  "prompt": "..."
+}
+```
+
+A successful response will return a similar output to that shown below.
+
+```bash
+2024-09-11 01:36:20,873.873 INFO     [Instill] Starting model image...
+2024-09-11 01:36:31,276.276 INFO     [Instill] Deploying model...
+2024-09-11 01:37:17,296.296 INFO     [Instill] Running inference...
+2024-09-11 01:37:20,402.402 INFO     [Instill] Outputs:
+[{'data': {'choices': [{'created': 1725989840,
+                        'finish-reason': 'length',
+                        'index': 0,
+                        'message': {'content': 'Hello! How may I assist you '
+                                               'today?',
+                                    'role': 'assistant'}}]}}]
+2024-09-11 01:37:24,165.165 INFO     [Instill] Done
+```
+
+Here is the list of flags supported by `instill run` command
+
+- -t, --tag: tag for the model image, default to `latest`
+- -g, --gpu: to pass through GPU from host into container or not, depends on if `gpu` is enabled in the config.
+- -i, --input: input in json format
+
+---
+
+Happy Modeling! 💡


### PR DESCRIPTION
Because

- Introduce each Instill Model compatible implementation of various models

This commit

- populate models' readme
