### PR TITLE
chore(vllm): upgrade version to 0.8.3

### DIFF
--- a/functionary-medium-v3.2/v0.1.0/instill.yaml
+++ b/functionary-medium-v3.2/v0.1.0/instill.yaml
@@ -1,5 +1,5 @@
 build:
   gpu: true
-  python_version: "3.11"  # support only 3.11
+  python_version: "3.11" # support only 3.11
   python_packages:
-    - vllm==0.6.4.post1
+    - vllm==0.8.3

--- a/gemma-2-27b-it/v0.1.0/instill.yaml
+++ b/gemma-2-27b-it/v0.1.0/instill.yaml
@@ -1,6 +1,6 @@
 build:
   gpu: true
-  python_version: "3.11"  # support only 3.11
+  python_version: "3.11" # support only 3.11
   python_packages:
-    - vllm==0.6.4.post1
+    - vllm==0.8.3
     - bitsandbytes==0.45.0

--- a/jina-clip-v1/v0.1.0/instill.yaml
+++ b/jina-clip-v1/v0.1.0/instill.yaml
@@ -1,6 +1,6 @@
 build:
   gpu: true
-  python_version: "3.11"  # support only 3.11
+  python_version: "3.11" # support only 3.11
   python_packages:
     - torch
     - transformers

--- a/llama-3-2-90b-vision-instruct/v0.1.0/instill.yaml
+++ b/llama-3-2-90b-vision-instruct/v0.1.0/instill.yaml
@@ -1,5 +1,5 @@
 build:
   gpu: true
-  python_version: "3.11"  # support only 3.11
+  python_version: "3.11" # support only 3.11
   python_packages:
-    - vllm==0.6.4.post1
+    - vllm==0.8.3

--- a/llama-3-3-70b-instruct/v0.1.1/instill.yaml
+++ b/llama-3-3-70b-instruct/v0.1.1/instill.yaml
@@ -1,6 +1,6 @@
 build:
   gpu: true
-  python_version: "3.11"  # support only 3.11
+  python_version: "3.11" # support only 3.11
   python_packages:
-    - vllm==0.6.4.post1
+    - vllm==0.8.3
     - bitsandbytes==0.45.0

--- a/qwen-2-5-72b-instruct/v0.1.0/instill.yaml
+++ b/qwen-2-5-72b-instruct/v0.1.0/instill.yaml
@@ -1,6 +1,5 @@
 build:
-  gpu: true
-  python_version: "3.11"  # support only 3.11
+  gpu: false
+  python_version: "3.11" # support only 3.11
   python_packages:
-    - vllm==0.6.4.post1
-    - bitsandbytes==0.45.0
+    - vllm==0.6.5

--- a/qwen-2-5-coder-32b-instruct/v0.1.0/instill.yaml
+++ b/qwen-2-5-coder-32b-instruct/v0.1.0/instill.yaml
@@ -1,6 +1,6 @@
 build:
   gpu: true
-  python_version: "3.11"  # support only 3.11
+  python_version: "3.11" # support only 3.11
   cuda_version: "12.1"
   python_packages:
-    - vllm==0.6.4.post1
+    - vllm==0.8.3


### PR DESCRIPTION
Because

- upgrade vllm to support arm64 and use ubuntu 22.04 base image 

This commit

- upgrade vllm to 0.8.3