### PR TITLE
chore(llama-3-2-3b-instruct): add vllm cpu version

### DIFF
--- a/llama-3-2-3b-instruct/v0.1.0-vllm-cpu/instill.yaml
+++ b/llama-3-2-3b-instruct/v0.1.0-vllm-cpu/instill.yaml
@@ -1,0 +1,5 @@
+build:
+  gpu: false
+  python_version: "3.11" # support only 3.11
+  python_packages:
+    - vllm==0.8.3

--- a/llama-3-2-3b-instruct/v0.1.0-vllm-cpu/model.py
+++ b/llama-3-2-3b-instruct/v0.1.0-vllm-cpu/model.py
@@ -1,0 +1,72 @@
+# pylint: skip-file
+from pathlib import Path
+from typing import List
+from vllm import LLM, SamplingParams, SamplingParams, RequestOutput
+from instill.helpers.ray_config import instill_deployment, InstillDeployable
+from instill.helpers import (
+    parse_task_chat_to_chat_input,
+    construct_task_chat_output,
+)
+
+
+@instill_deployment
+class Llama32Instruct:
+    def __init__(self):
+        self.model = LLM(
+            model="Llama-3.2-3B-Instruct",
+            max_model_len=4096,
+            dtype="float16",
+        )
+
+    async def __call__(self, request):
+        chat_inputs = await parse_task_chat_to_chat_input(request=request)
+
+        finish_reasons = []
+        indexes = []
+        created = []
+        messages = []
+        for inp in chat_inputs:
+            params = SamplingParams(
+                max_tokens=inp.max_tokens,
+                n=inp.n,
+                temperature=inp.temperature,
+                top_p=inp.top_p,
+            )
+
+            if inp.seed != 0:
+                params.seed = inp.seed
+
+            sequences: List[RequestOutput] = self.model.chat(
+                messages=inp.messages,
+                sampling_params=params,
+                use_tqdm=False,
+            )
+
+            finish_reasons_per_seq = []
+            indexes_per_seq = []
+            created_per_seq = []
+            messages_per_seq = []
+            for i, seq in enumerate(sequences):
+
+                messages_per_seq.append(
+                    {"content": seq.outputs[0].text, "role": "assistant"}
+                )
+                finish_reasons_per_seq.append(seq.outputs[0].finish_reason)
+                indexes_per_seq.append(i)
+                created_per_seq.append(int(seq.metrics.finished_time))
+
+            finish_reasons.append(finish_reasons_per_seq)
+            indexes.append(indexes_per_seq)
+            created.append(created_per_seq)
+            messages.append(messages_per_seq)
+
+        return construct_task_chat_output(
+            request=request,
+            finish_reasons=finish_reasons,
+            indexes=indexes,
+            created_timestamps=created,
+            messages=messages,
+        )
+
+
+entrypoint = InstillDeployable(Llama32Instruct).get_deployment_handle()


### PR DESCRIPTION
Because

- the upstream version of Ray and vllm can support arm64 CPU for serving model

This commit

- add a CPU version for `llama-3-2-3b-instruct` model
