### PR TITLE
feat(deepseek-r1): add models for both vllm and mlc-llm runtimes

### DIFF
--- a/deepseek-r1-distill-qwen-1.5b/README.md
+++ b/deepseek-r1-distill-qwen-1.5b/README.md
@@ -5,6 +5,7 @@
 [DeepSeek-R1-Distill-Qwen-1.5B](https://huggingface.co/deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B) is a compact yet powerful language model distilled from DeepSeek-R1, specifically designed for reasoning tasks. This model is based on the Qwen2.5-Math-1.5B architecture and has been fine-tuned using knowledge distilled from the larger DeepSeek-R1 model.
 
 Key features:
+
 - Built on Qwen2.5-Math-1.5B as the base model
 - Distilled from DeepSeek-R1 using reasoning-focused training data
 - Optimized for mathematical reasoning, coding, and general problem-solving tasks

--- a/deepseek-r1-distill-qwen-7b/README.md
+++ b/deepseek-r1-distill-qwen-7b/README.md
@@ -1,0 +1,87 @@
+# DeepSeek R1 Distill Qwen 7B
+
+## 📖 Introduction
+
+[DeepSeek-R1-Distill-Qwen-7B](https://huggingface.co/deepseek-ai/DeepSeek-R1-Distill-Qwen-7B) is a powerful language model distilled from DeepSeek-R1, specifically designed for reasoning tasks.
+
+| Task Type                                                  | Description                                         |
+| ---------------------------------------------------------- | --------------------------------------------------- |
+| [Chat](https://www.instill-ai.dev/docs/model/ai-task#chat) | A task to generate conversational style text output |
+
+## 🔄 Compatibility Matrix
+
+To ensure smooth integration, please refer to the compatibility matrix below. It outlines the compatible versions of the model, [`instill-core`](https://github.com/instill-ai/instill-core), and the [`python-sdk`](https://github.com/instill-ai/python-sdk).
+
+| Model Version | Instill-Core Version | Python-SDK Version |
+| ------------- | -------------------- | ------------------ |
+| v0.1.0        | >v0.46.0-beta        | >0.16.0            |
+
+> **Note:** Always ensure that you are using compatible versions to avoid unexpected issues.
+
+## 🚀 Preparation
+
+Follow [this](../README.md) guide to get your custom model up and running! But before you do that, please read through the following sections to have all the necessary files ready.
+
+#### Install Python SDK
+
+Install the compatible [`python-sdk`](https://github.com/instill-ai/python-sdk) version according to the compatibility matrix:
+
+```bash
+pip install instill-sdk=={version}
+```
+
+#### Get model weights
+
+To download the fine-tuned model weights, please execute the following command:
+
+```bash
+git clone https://huggingface.co/mlc-ai/DeepSeek-R1-Distill-Qwen-14B-q4f32_1-MLC
+```
+
+## Test model image
+
+After you've built the model image, and before pushing the model onto any **Instill Core** instance, you can test if the model can be successfully run locally first, by running the following command:
+
+```bash
+instill run admin/deepseek-r1-distill-qwen-7b -g -i '{"prompt": "what is the capital of England?"}'
+```
+
+The input payload should strictly follow the the below format
+
+```json
+{
+  "prompt": "..."
+}
+```
+
+A successful response will return a similar output to that shown below.
+
+```bash
+2025-01-31 15:10:25,002.002 INFO     [Instill] Starting model image...
+2025-01-31 15:10:30,245.245 INFO     [Instill] Deploying model...
+2025-01-31 15:10:38,919.919 INFO     [Instill] Running inference...
+2025-01-31 07:10:56,594.594 INFO     [Instill] Outputs:
+[{'data': {'choices': [{'created': 1738336256,
+                        'finish-reason': 'length',
+                        'index': 0,
+                        'message': {'content': '<｜begin▁of▁sentence｜><｜User｜>what '
+                                               'is the capital of '
+                                               'England?<｜Assistant｜><think>\n'
+                                               '\n'
+                                               '</think>\n'
+                                               '\n'
+                                               'The capital of England is '
+                                               'London.',
+                                    'role': 'assistant'}}]}}]
+2025-01-31 15:11:00,325.325 INFO     [Instill] Done
+```
+
+Here is the list of flags supported by `instill run` command
+
+- -t, --tag: tag for the model image, default to `latest`
+- -g, --gpu: to pass through GPU from host into container or not, depends on if `gpu` is enabled in the config.
+- -i, --input: input in json format
+
+---
+
+Happy Modeling! 💡

--- a/deepseek-r1-distill-qwen-7b/v0.1.0/.gitignore
+++ b/deepseek-r1-distill-qwen-7b/v0.1.0/.gitignore
@@ -1,1 +1,1 @@
-DeepSeek-R1-Distill-Qwen-14B-q4f32_1-MLC
+DeepSeek-R1-Distill-Qwen-7B-q4f16_1-MLC

--- a/deepseek-r1-distill-qwen-7b/v0.1.0/.gitignore
+++ b/deepseek-r1-distill-qwen-7b/v0.1.0/.gitignore
@@ -1,0 +1,1 @@
+DeepSeek-R1-Distill-Qwen-14B-q4f32_1-MLC

--- a/deepseek-r1-distill-qwen-7b/v0.1.0/instill.yaml
+++ b/deepseek-r1-distill-qwen-7b/v0.1.0/instill.yaml
@@ -1,0 +1,5 @@
+build:
+  gpu: true
+  python_version: "3.11"  # support only 3.11
+  python_packages:
+    - mlc-llm

--- a/deepseek-r1-distill-qwen-7b/v0.1.0/instill.yaml
+++ b/deepseek-r1-distill-qwen-7b/v0.1.0/instill.yaml
@@ -2,4 +2,4 @@ build:
   gpu: true
   python_version: "3.11"  # support only 3.11
   python_packages:
-    - mlc-llm
+    - "--pre -U -f https://mlc.ai/wheels mlc-llm-nightly-cu122 mlc-ai-nightly-cu122"

--- a/deepseek-r1-distill-qwen-7b/v0.1.0/instill.yaml
+++ b/deepseek-r1-distill-qwen-7b/v0.1.0/instill.yaml
@@ -1,5 +1,3 @@
 build:
-  gpu: true
-  python_version: "3.11"  # support only 3.11
-  python_packages:
-    - "--pre -U -f https://mlc.ai/wheels mlc-llm-nightly-cu122 mlc-ai-nightly-cu122"
+  gpu: false
+  llm_runtime: "mlc-llm"

--- a/deepseek-r1-distill-qwen-7b/v0.1.0/model.py
+++ b/deepseek-r1-distill-qwen-7b/v0.1.0/model.py
@@ -11,7 +11,7 @@ from instill.helpers import (
 @instill_deployment
 class DeepSeekR1DistillQwen7B:
     def __init__(self):
-        self.model = "DeepSeek-R1-Distill-Qwen-14B-q4f32_1-MLC"
+        self.model = "DeepSeek-R1-Distill-Qwen-7B-q4f16_1-MLC"
         self.engine = AsyncMLCEngine(self.model)
 
     async def __call__(self, request):
@@ -52,6 +52,4 @@ class DeepSeekR1DistillQwen7B:
         )
 
 
-entrypoint = InstillDeployable(
-    DeepSeekR1DistillQwen7B
-).get_deployment_handle()
+entrypoint = InstillDeployable(DeepSeekR1DistillQwen7B).get_deployment_handle()

--- a/deepseek-r1-distill-qwen-7b/v0.1.0/model.py
+++ b/deepseek-r1-distill-qwen-7b/v0.1.0/model.py
@@ -1,0 +1,57 @@
+import time
+from mlc_llm import AsyncMLCEngine
+
+from instill.helpers.ray_config import instill_deployment, InstillDeployable
+from instill.helpers import (
+    parse_task_chat_to_chat_input,
+    construct_task_chat_output,
+)
+
+
+@instill_deployment
+class DeepSeekR1DistillQwen7B:
+    def __init__(self):
+        self.model = "DeepSeek-R1-Distill-Qwen-14B-q4f32_1-MLC"
+        self.engine = AsyncMLCEngine(self.model)
+
+    async def __call__(self, request):
+        conversation_inputs = await parse_task_chat_to_chat_input(
+            request=request
+        )
+
+        finish_reasons = []
+        indexes = []
+        created = []
+        messages = []
+        for i, inp in enumerate(conversation_inputs):
+            print(inp.messages)
+
+            # Use MLC-LLM chat completions API
+            response = await self.engine.chat.completions.create(
+                messages=inp.messages,
+                model=self.model,
+                max_tokens=inp.max_tokens,
+                temperature=inp.temperature,
+                top_p=inp.top_p,
+                stream=False,
+            )
+
+            output = response.choices[0].message.content.strip()
+
+            messages.append([{"content": output, "role": "assistant"}])
+            finish_reasons.append(["length"])
+            indexes.append([i])
+            created.append([int(time.time())])
+
+        return construct_task_chat_output(
+            request=request,
+            finish_reasons=finish_reasons,
+            indexes=indexes,
+            messages=messages,
+            created_timestamps=created,
+        )
+
+
+entrypoint = InstillDeployable(
+    DeepSeekR1DistillQwen7B
+).get_deployment_handle()

--- a/deepseek-r1-distill-qwen-7b/v0.1.1/.gitignore
+++ b/deepseek-r1-distill-qwen-7b/v0.1.1/.gitignore
@@ -1,0 +1,1 @@
+DeepSeek-R1-Distill-Qwen-7B

--- a/deepseek-r1-distill-qwen-7b/v0.1.1/instill.yaml
+++ b/deepseek-r1-distill-qwen-7b/v0.1.1/instill.yaml
@@ -1,0 +1,5 @@
+build:
+  gpu: true
+  python_version: "3.11"  # support only 3.11
+  python_packages:
+    - vllm

--- a/deepseek-r1-distill-qwen-7b/v0.1.1/instill.yaml
+++ b/deepseek-r1-distill-qwen-7b/v0.1.1/instill.yaml
@@ -1,5 +1,3 @@
 build:
   gpu: true
-  python_version: "3.11"  # support only 3.11
-  python_packages:
-    - vllm
+  llm_runtime: "vllm"

--- a/deepseek-r1-distill-qwen-7b/v0.1.1/model.py
+++ b/deepseek-r1-distill-qwen-7b/v0.1.1/model.py
@@ -1,0 +1,74 @@
+from typing import List
+from vllm import LLM, SamplingParams, RequestOutput
+from instill.helpers.ray_config import instill_deployment, InstillDeployable
+from instill.helpers import (
+    parse_task_chat_to_chat_input,
+    construct_task_chat_output,
+)
+
+
+@instill_deployment
+class DeepSeekR1DistillQwen7B:
+    def __init__(self):
+        self.model = LLM(
+            model="DeepSeek-R1-Distill-Qwen-7B",
+            dtype="float16",
+            max_model_len=8192,
+        )
+
+    async def __call__(self, request):
+        chat_inputs = await parse_task_chat_to_chat_input(request=request)
+
+        finish_reasons = []
+        indexes = []
+        created = []
+        messages = []
+
+        for inp in chat_inputs:
+            params = SamplingParams(
+                max_tokens=inp.max_tokens,
+                temperature=inp.temperature,
+                top_p=inp.top_p,
+                n=inp.n,
+            )
+
+            if inp.seed != 0:
+                params.seed = inp.seed
+
+            sequences: List[RequestOutput] = self.model.chat(
+                messages=inp.messages,
+                sampling_params=params,
+                use_tqdm=False,
+            )
+
+            finish_reasons_per_seq = []
+            indexes_per_seq = []
+            created_per_seq = []
+            messages_per_seq = []
+
+            for i, seq in enumerate(sequences):
+                messages_per_seq.append({
+                    "content": seq.outputs[0].text,
+                    "role": "assistant"
+                })
+                finish_reasons_per_seq.append(seq.outputs[0].finish_reason)
+                indexes_per_seq.append(i)
+                created_per_seq.append(int(seq.metrics.finished_time))
+
+            finish_reasons.append(finish_reasons_per_seq)
+            indexes.append(indexes_per_seq)
+            created.append(created_per_seq)
+            messages.append(messages_per_seq)
+
+        return construct_task_chat_output(
+            request=request,
+            finish_reasons=finish_reasons,
+            indexes=indexes,
+            created_timestamps=created,
+            messages=messages,
+        )
+
+
+entrypoint = InstillDeployable(
+    DeepSeekR1DistillQwen7B
+).get_deployment_handle()


### PR DESCRIPTION
Because

- add `deepseek-r1-distill-qwen-7b` model for both `vllm` and `mlc-llm` runtimes.

This commit

- adopted Python SDK `v0.18.0` for the latest `instill.yaml` format.
